### PR TITLE
Add another way to run random fun Transformer

### DIFF
--- a/transformer_unify.ipynb
+++ b/transformer_unify.ipynb
@@ -158,11 +158,90 @@
    "source": [
     "(l2 == y).all() # cool"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([8, 512, 512])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q1a =  F.gelu(layer1(q))\n",
+    "print(q1a.shape)\n",
+    "torch.allclose(q1a,att)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([8, 512, 128])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q2a =  layer2(q1a)\n",
+    "y =  att @ v\n",
+    "print(q2a.shape)\n",
+    "torch.allclose(q2a,y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(True)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(q2a == y).all()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -176,7 +255,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "277b78f2730b0903abf2859ae01821a113fbf907e4071225ef1d3ec9542f1da7"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Please don't hesitate to close this one.


I reproduced the all-attention model.

It looks like I can't really use your Linear. weight to dot with another vector because Python told me It is in CPU and other parts are in GPU. Thus, I have to change it to do linear(q).

Thus, this pull request is about changing from the weight.T to linear(q), etc.

The result is not good.  I guess they are right that you can't remove the Softmax. 

1. This is a sign that an efficient Transformer doesn't mean it is about going it all MLP. 

2. Or I am wrong here because one or some of the residual connections are missing with the All-Attetion?

If you are interested, please feel free to check out the notebook or the website to see how I trained the model with the Shapkeare dataset with my own version of Nano GPT. 
The number of parameters goes from 19 to 12 with All Attention, but the result is not great.
https://github.com/JonathanSum/NLP-Notebooks-Andrej-Course/blob/main/gpt2_part2.ipynb
Website result:
https://jonathansum.github.io/Blog/#/gpt2_part2
![image](https://user-images.githubusercontent.com/21982975/215523415-f599a23f-d6f4-4075-a9b4-2de17dfc8ff4.png)
